### PR TITLE
removed duplicate resize block from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,11 +164,6 @@ player.analytics({
       action: 'error',
     },
     {
-      name: 'resize',
-      label: 'resize',
-      action: 'resize',
-    },
-    {
       name: 'resolutionchange',
       action: 'resolution change',
     },


### PR DESCRIPTION
looks like the resize block was copied twice in this example.